### PR TITLE
twrp: Use `OUT_DIR`

### DIFF
--- a/twrp.mk
+++ b/twrp.mk
@@ -69,7 +69,7 @@ TW_INCLUDE_CRYPTO_FBE := true
 
 # Add strace
 TARGET_RECOVERY_DEVICE_MODULES      += strace
-TW_RECOVERY_ADDITIONAL_RELINK_FILES += $(OUT)/system/xbin/strace
+TW_RECOVERY_ADDITIONAL_RELINK_FILES += $(OUT_DIR)/system/xbin/strace
 
 # /system/manifest.xml
 TARGET_RECOVERY_DEVICE_MODULES      += system_manifest.xml


### PR DESCRIPTION
 * `OUT` usage is deprecated now. Use `OUT_DIR` instead. 

```
error: OUT is obsolete. Use OUT_DIR instead. See https://android.googlesource.com/platform/build/+/master/Changes.md#OUT.
```